### PR TITLE
Update component guide link

### DIFF
--- a/.github/CODE_GUIDELINES.md
+++ b/.github/CODE_GUIDELINES.md
@@ -488,7 +488,7 @@ If you're on Linux you need to compile both yourself manually, obviously.
 You can spawn in a target dummy (`/mob/living/carbon/human/tdummy`) to more easily test things that do damage - they have the ass day health percent and damage popups visible even if your build isn't set to ass day.
 
 ## Signals and Components
-ninjanomnom from TG has written up a [useful primer](https://tgstation13.org/phpBB/viewtopic.php?f=5&t=22674) on signals and components. Most of the stuff there applies, although elements do not exist in this codebase.
+ninjanomnom from TG has written up a [useful primer](https://hackmd.io/@tgstation/SignalsComponentsElements) on signals and components. Most of the stuff there applies, although elements do not exist in this codebase.
 
 ## Generic Action bar
 Hate coding action bars? Making a new definition for an action bar datum just so you have visual feedback for your construction feel gross? Well fear not! You can now use the SETUP_GENERIC_ACTIONBAR() macro!


### PR DESCRIPTION
[DOCUMENTATION]
## About the PR
Replaces an outdated link with the new version leading straight to the hackmd.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
The old page still worked but had a big header redirecting to another page. Might as well just use the other page.